### PR TITLE
(BOLT-1053) Symbolize all keys for task params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.3.0
+
+**Bugfixes**
+
+Previously only top level parameter keys were symbolized. Now nested keys are also symbolized.
+
 ## Release 0.2.0
 
 **Bugfixes**

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add it to your [task metadata](https://puppet.com/docs/bolt/latest/writing_tasks
 
 ## Usage
 
-When writing your task include the library in your script, extend the `TaskHelper` module, and write the `task()` function. The `task()` function should accept its parameters as symbols, and should return a hash. The following is an example of a task that uses the library
+When writing your task include the library in your script, extend the `TaskHelper` module, and write the `task()` function. The `task()` function should accept its parameters as symbols, and should return a hash. The following is an example of a task that uses the library. All parameters will be symbolized including nested hash keys and hashes contained in arrays.
 
 `mymodule/tasks/task.rb`
 ```

--- a/examples/mytask.json
+++ b/examples/mytask.json
@@ -2,8 +2,8 @@
   "description": "An example task that uses the ruby helper library",
   "input_method": "both",
   "parameters": {
-    "action": {
-      "description": "abcd",
+    "name": {
+      "description": "Name of user you would like to greet.",
       "type": "String"
     }
   },

--- a/examples/mytask.rb
+++ b/examples/mytask.rb
@@ -1,6 +1,15 @@
 #!/usr/bin/env ruby
 
-require_relative '../files/task_helper.rb'
+installdir_path = "../../ruby_task_helper/files/task_helper.rb"
+local_path = "../files/task_helper.rb"
+
+# Task is being run with bolt and helper is at location relative to task
+if File.exist?(installdir_path)
+	require_relative installdir_path
+# TODO MODULES-8605 reccomend efficient pattern for testing locally
+else
+	require_relative local_path
+end
 
 class MyTask < TaskHelper
   def task(name: nil, **kwargs)
@@ -8,4 +17,6 @@ class MyTask < TaskHelper
   end
 end
 
-MyTask.run if __FILE__ == $0
+if __FILE__ == $0
+  MyTask.run
+end

--- a/examples/task_test.rb
+++ b/examples/task_test.rb
@@ -1,3 +1,4 @@
+require 'json'
 require_relative './mytask.rb'
 
 # An example of testing a task using the helper
@@ -5,8 +6,8 @@ require_relative './mytask.rb'
 describe 'MyTask' do
   it 'runs my task' do
     allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
-    expect(MyTask).to receive(:run).and_return('{greeting:
-                                                 "Hi, my name is Lucy"}')
+    out = JSON.dump('greeting' => 'Hi, my name is Lucy')
+    expect(STDOUT).to receive(:print).with(out)
     MyTask.run
   end
 end

--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -23,12 +23,24 @@ class TaskHelper
     raise TaskHelper::Error.new(msg, 'tasklib/not-implemented')
   end
 
+  # Accepts a Data object and returns a copy with all hash keys
+  # symbolized.
+  def self.walk_keys(data)
+    if data.is_a? Hash
+      data.each_with_object({}) do |(k, v), acc|
+        v = walk_keys(v)
+        acc[k.to_sym] = v
+      end
+    elsif data.is_a? Array
+      data.map { |v| walk_keys(v) }
+    else
+      data
+    end
+  end
+
   def self.run
     input = STDIN.read
-    # Line is too long for rubocop :P
-    params = JSON.parse(input).each_with_object({}) do |(k, v), acc|
-      acc[k.to_sym] = v
-    end
+    params = walk_keys(JSON.parse(input))
 
     # This method accepts a hash of parameters to run the task, then executes
     # the task. Unhandled errors are caught and turned into an error result.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ruby_task_helper",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Puppet, Inc.",
   "summary": "A helper for writing tasks in ruby",
   "license": "Apache-2.0",

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../files/task_helper.rb'
+require 'json'
 
 class EmptyTask < TaskHelper; end
 
@@ -13,6 +14,20 @@ end
 class EchoTask < TaskHelper
   def task(name: nil)
     { 'result': "Hi, my name is #{name}" }
+  end
+end
+
+class SymbolizeTask < TaskHelper
+  def task(params)
+    # Test that the keys have been symbolized.
+    symbols = {
+      nested_hash: params.dig(:top_level, :nested_key),
+      array_hash: params[:array_keys].first[:array_key]
+    }
+    # Return the parameters merged with the symbols for
+    # verification in test.
+    result = params.merge(symbols)
+    { 'result': JSON.dump(result) }
   end
 end
 
@@ -59,5 +74,25 @@ describe 'EchoTask' do
     expect(EchoTask).to receive(:run).and_return('{"result":
                                                  "Hello, my name is Lucy"}')
     EchoTask.run
+  end
+end
+
+describe 'SymbolizeTask' do
+  it 'recieves parameters hash with symbolized keys' do
+    params = {
+      'top_level' => { 'nested_key' => 'foo' },
+      'array_keys' => [{ 'array_key' => 'bar' }]
+    }
+    # The task will only return these values if the keys
+    # are properly symbolized.
+    symbols = { nested_hash: 'foo', array_hash: 'bar' }
+    allow(STDIN).to receive(:read).and_return(JSON.dump(params))
+    # In order to verify that symbolizing keys has not corrupted
+    # the structure of the parameters the task returns the params
+    # hash it received. This is merged with the result of looking
+    # up the symbolized keys.
+    out = JSON.dump('result' => JSON.dump(params.merge(symbols)))
+    expect(STDOUT).to receive(:print).with(out)
+    SymbolizeTask.run
   end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -71,8 +71,8 @@ end
 describe 'EchoTask' do
   it 'runs an echo task' do
     allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
-    expect(EchoTask).to receive(:run).and_return('{"result":
-                                                 "Hello, my name is Lucy"}')
+    out = JSON.dump('result' => 'Hi, my name is Lucy')
+    expect(STDOUT).to receive(:print).with(out)
     EchoTask.run
   end
 end


### PR DESCRIPTION
Previously only top level keys were symbolized to be passed to the `task` instance method intended to be overridden by users of the task helper. This commit symbolizes all keys in nested hashes and hashes contained in arrays.