### PR TITLE
Wrap errors in _error key

### DIFF
--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -54,11 +54,11 @@ class TaskHelper
       STDOUT.print result.to_s
     end
   rescue TaskHelper::Error => e
-    STDOUT.print(e.to_h.to_json)
+    STDOUT.print({_error: e.to_h}.to_json)
     exit 1
   rescue StandardError => e
     error = TaskHelper::Error.new(e.message, e.class.to_s, e.backtrace)
-    STDOUT.print(error.to_h.to_json)
+    STDOUT.print({_error: error.to_h}.to_json)
     exit 1
   end
 end

--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -54,11 +54,11 @@ class TaskHelper
       STDOUT.print result.to_s
     end
   rescue TaskHelper::Error => e
-    STDOUT.print({_error: e.to_h}.to_json)
+    STDOUT.print({ _error: e.to_h }.to_json)
     exit 1
   rescue StandardError => e
     error = TaskHelper::Error.new(e.message, e.class.to_s, e.backtrace)
-    STDOUT.print({_error: error.to_h}.to_json)
+    STDOUT.print({ _error: error.to_h }.to_json)
     exit 1
   end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -34,11 +34,11 @@ end
 describe 'EmptyTask' do
   it 'returns no method when task() is not provided' do
     allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
-    out = '{"kind":"tasklib/not-implemented",' \
-      '"msg":"The task author must implement the `task` method in the task",' \
-      '"details":{}}'
+    result = { _error: { kind: 'tasklib/not-implemented',
+                         msg: "The task author must implement the `task` method in the task",
+                         details: {} } }
     # This needs to be done before the process that exits is run
-    expect(STDOUT).to receive(:print).with(out)
+    expect(STDOUT).to receive(:print).with(result.to_json)
 
     begin
       EmptyTask.run
@@ -53,10 +53,11 @@ end
 describe 'ErrorTask' do
   it 'raises an error' do
     allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
-    out = '{"kind":"task/error-kind",' \
-      '"msg":"task error message","details":"Additional details"}'
+    result = { _error: { kind: 'task/error-kind',
+                         msg: "task error message",
+                         details: "Additional details" } }
     # This needs to be done before the process that exits is run
-    expect(STDOUT).to receive(:print).with(out)
+    expect(STDOUT).to receive(:print).with(result.to_json)
 
     begin
       ErrorTask.run

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -34,9 +34,11 @@ end
 describe 'EmptyTask' do
   it 'returns no method when task() is not provided' do
     allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
-    result = { _error: { kind: 'tasklib/not-implemented',
-                         msg: "The task author must implement the `task` method in the task",
-                         details: {} } }
+    msg = 'The task author must implement the `task` method in the task'
+    result = { _error:
+               { kind: 'tasklib/not-implemented',
+                 msg: msg,
+                 details: {} } }
     # This needs to be done before the process that exits is run
     expect(STDOUT).to receive(:print).with(result.to_json)
 
@@ -54,8 +56,8 @@ describe 'ErrorTask' do
   it 'raises an error' do
     allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
     result = { _error: { kind: 'task/error-kind',
-                         msg: "task error message",
-                         details: "Additional details" } }
+                         msg: 'task error message',
+                         details: 'Additional details' } }
     # This needs to be done before the process that exits is run
     expect(STDOUT).to receive(:print).with(result.to_json)
 


### PR DESCRIPTION
Previously, the task helper would rescue errors in the `run` method and
simply print their hashified version. This caused Bolt to synthesize its own
`_error` object (simply stating the task failed and its exit code) which
took precedence over the actual underlying cause.

We now properly wrap the result in `_error` so Bolt knows that it should
display that information to the user.