### PR TITLE
Add module lib/ to LOAD_PATH

### DIFF
--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -25,11 +25,13 @@ class TaskHelper
 
   # Adds the <module>/lib/ directory for all modules in the _installdir.
   # This eases the pain for module authors when writing tasks that utilize
-  # code in the lib/ directory that `require` files also in that same lib/ directory.
-  def self.add_module_lib_paths(install_dir=ENV['PT__installdir'])
+  # code in the lib/ directory that `require` files also in that same lib/
+  # directory.
+  def self.add_module_lib_paths(install_dir = ENV['PT__installdir'])
     if install_dir.nil?
-      error = TaskHelper::Error.new('"PT__installdir" environment variable was not set. You should try setting "input": "both" in your task metadata JSON file.',
-                                    'ArgumentError')
+      msg = '"PT__installdir" environment variable was not set. You should try'\
+            'setting "input": "both" in your task metadata JSON file.'
+      error = TaskHelper::Error.new(msg, 'ArgumentError')
       STDOUT.print({ _error: error.to_h }.to_json)
       exit 1
     end

--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -26,7 +26,14 @@ class TaskHelper
   # Adds the <module>/lib/ directory for all modules in the _installdir.
   # This eases the pain for module authors when writing tasks that utilize
   # code in the lib/ directory that `require` files also in that same lib/ directory.
-  def self.add_module_lib_paths(install_dir)
+  def self.add_module_lib_paths(install_dir=ENV['PT__installdir'])
+    if install_dir.nil?
+      error = TaskHelper::Error.new('"PT__installdir" environment variable was not set. You should try setting "input": "both" in your task metadata JSON file.',
+                                    'ArgumentError')
+      STDOUT.print({ _error: error.to_h }.to_json)
+      exit 1
+    end
+
     Dir.glob(File.join([install_dir, '*'])).each do |mod|
       $LOAD_PATH << File.join([mod, 'lib'])
     end

--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -23,6 +23,15 @@ class TaskHelper
     raise TaskHelper::Error.new(msg, 'tasklib/not-implemented')
   end
 
+  # Adds the <module>/lib/ directory for all modules in the _installdir.
+  # This eases the pain for module authors when writing tasks that utilize
+  # code in the lib/ directory that `require` files also in that same lib/ directory.
+  def self.add_module_lib_paths(install_dir)
+    Dir.glob(File.join([install_dir, '*'])).each do |mod|
+      $LOAD_PATH << File.join([mod, 'lib'])
+    end
+  end
+
   # Accepts a Data object and returns a copy with all hash keys
   # symbolized.
   def self.walk_keys(data)
@@ -41,6 +50,7 @@ class TaskHelper
   def self.run
     input = STDIN.read
     params = walk_keys(JSON.parse(input))
+    add_module_lib_paths(params[:_installdir]) if params[:_installdir]
 
     # This method accepts a hash of parameters to run the task, then executes
     # the task. Unhandled errors are caught and turned into an error result.

--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -1,8 +1,8 @@
 require 'json'
 
 class TaskHelper
-  @@params = nil
-  
+  @@params = nil # rubocop:disable Style/ClassVars
+
   class Error < RuntimeError
     attr_reader :kind, :details, :issue_code
 
@@ -53,14 +53,16 @@ class TaskHelper
   end
 
   def self.params
+    # rubocop:disable Style/ClassVars
     return @@params if @@params
     input = STDIN.read
     @@params = walk_keys(JSON.parse(input))
+    # rubocop:enable Style/ClassVars
   end
-  
+
   def self.run
     add_module_lib_paths(params[:_installdir])
-    
+
     # This method accepts a hash of parameters to run the task, then executes
     # the task. Unhandled errors are caught and turned into an error result.
     # @param [Hash] params A hash of params for the task


### PR DESCRIPTION
Currently, when writing ruby tasks, there can be a bit of an issue with `require` statements for things in a module's `lib` directory.

Normally these files do a `require puppet/whatever`. Puppet makes this possible by adding the `lib` directory to Ruby's `LOAD_PATH` when it compiles its catalogs.

In Bolt however the LOAD_PATH isn't modified in the same way and it causes a bit of grief if you try to `require` something in `lib`. This is especially evident when that class/module in `lib` also does a `require` for something else in `lib`.

To fix this problem i noticed that the `cisco_ios` module solves this by modifying the `LOAD_PATH` early on in the Task's lifetime: 

https://github.com/puppetlabs/cisco_ios/blob/master/lib/puppet/util/task_helper.rb#L34-L39

I've taken this idea and expanded upon it by allowing it to be used in two different ways in the Ruby TaskHelper:

### Option 1 - Global access using PT__installdir

At the top of a Ruby task file you could do something like so:
```
#!/usr/bin/env ruby
require_relative '../../ruby_task_helper/files/task_helper.rb'
# adds all <module>/lib path's into LOAD_PATH by inspecting PT__installdir
TaskHelper.add_module_lib_paths

require 'puppet_x/owner/module/myclass'
```

### Option 2 - Using _installdir from stdin before task() is called

Alternatively, if that environment variable doesn't exist, we can allow the user to do the `require` inside of the `task()` method in their ruby code.

We can accomplish this by reading in the parameters from `stdin`, parsing out `_installdir` and then modifying `LOAD_PATH` before `task()` is called.

```
#!/usr/bin/env ruby
require_relative '../../ruby_task_helper/files/task_helper.rb'

# Bolt task for enabling/disabling monitoring alerts in SolarWinds
class MonitoringSolarwindsTask < TaskHelper

  def task(nodes: nil,
           action: nil,
           **kwargs) 
    require 'puppet_x/encore/patching/orion_client'
    # do something with the required class
  end
end

MonitoringSolarwindsTask.run if __FILE__ == $0


