### PR TITLE
Add 'debug' and 'debug_statements' methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.5.0
+
+### New features
+
+* Added a `debug` method to add debugging statements to the `details` field of a `TaskError`.
+
+* Added a `debug_statements` method to retrieve the current list of debugging statements.
+
 ## Release 0.4.0
 
-**Bugfixes**
+### Bug fixes
 
-Previously error hashes were not wrapped under an `_error` key causing bolt to ignore underlying error message. Now error hashes are wrapped under the expected `_error` key.
+* Previously error hashes were not wrapped under an `_error` key causing bolt to ignore underlying error message. 
+  Now error hashes are wrapped under the expected `_error` key.
 
 ## Release 0.3.0
 
-**Bugfixes**
+### Bug fixes
 
-Previously only top level parameter keys were symbolized. Now nested keys are also symbolized.
+* Previously only top level parameter keys were symbolized. Now nested keys are also symbolized.
 
 ## Release 0.2.0
 
-**Bugfixes**
+### Bug fixes
 
-Helper files should go in the `files` directory of a module to prevent them from being added to the puppet ruby loadpath or seen as tasks.
+* Helper files should go in the `files` directory of a module to prevent them from being added to the puppet 
+  ruby loadpath or seen as tasks.
 
 ## Release 0.1.0
 
-**Features**
-
-**Bugfixes**
-
-**Known Issues**
+This is the initial release.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Ruby helper library for writing [Puppet tasks](https://puppet.com/docs/bolt/la
 1. [Requirements](#requirements)
 1. [Setup](#setup)
 1. [Usage](#usage)
+1. [Debugging](#debugging)
+1. [Testing](#testing)
 
 ## Description
 
@@ -21,12 +23,12 @@ This library works with Ruby 2.3 and later.
 
 To use this library, include this module in a [Puppetfile](https://puppet.com/docs/pe/2019.0/puppetfile.html):
 
-```
+```ruby
 mod 'puppetlabs-ruby_task_helper'
 ```
 
 Add it to your [task metadata](https://puppet.com/docs/bolt/latest/writing_tasks.html#concept-677)
-```
+```json
 {
   "files": ["ruby_task_helper/files/task_helper.rb"],
   "input_method": "stdin"
@@ -38,7 +40,7 @@ Add it to your [task metadata](https://puppet.com/docs/bolt/latest/writing_tasks
 When writing your task include the library in your script, extend the `TaskHelper` module, and write the `task()` function. The `task()` function should accept its parameters as symbols, and should return a hash. The following is an example of a task that uses the library. All parameters will be symbolized including nested hash keys and hashes contained in arrays.
 
 `mymodule/tasks/mytask.rb`
-```
+```ruby
 #!/usr/bin/env ruby
 
 require_relative "../../ruby_task_helper/files/task_helper.rb"
@@ -55,17 +57,40 @@ end
 ```
 
 You can then run the task like any other Bolt task:
-```
+```bash
 bolt task run mymodule::task -n target.example.com name="Robert'); DROP TABLE Students;--"
 ```
 
 You can additionally provide detailed errors by raising a `TaskError`, such as
-```
+```ruby
 class MyTask < TaskHelper
   def task(**kwargs)
     raise TaskHelper::Error.new("my task error message",
                                "mytask/error-kind",
                                "Additional details")
+```
+
+## Debugging
+
+When writing your task, it can be helpful to write debugging statement to locate
+the source of any errors. The library includes a `debug` method that accepts arbitrary
+values and logs it as a debugging statement. If the task errors, the list of
+debugging statements will be included in the resulting `TaskError`.
+
+The list of debugging statements can also be accessed from the task itself by calling
+the `debug_statements` method. This can be used to include the debugging statements in
+a `TaskError` that you explicitly raise.
+
+Adding a debugging statement:
+```ruby
+debug "Result of method call: #{result}
+```
+
+Adding the list of debugging statements to a `TaskError`:
+```ruby
+raise TaskHelper::Error.new("my task error message",
+                            "mytask/error-kind",
+                            "debug" => debug_statements)
 ```
 
 ## Testing

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -11,6 +11,14 @@ class ErrorTask < TaskHelper
   end
 end
 
+class DebugTask < TaskHelper
+  def task(name: nil)
+    debug('debugging statement')
+    debug('another debugging statement')
+    raise StandardError, 'There was an error'
+  end
+end
+
 class EchoTask < TaskHelper
   def task(name: nil)
     { 'result': "Hi, my name is #{name}" }
@@ -67,6 +75,24 @@ describe 'ErrorTask' do
       expect(e.status).to eq(1)
     else
       raise 'The ErrorTask test did not exit 1 as expected'
+    end
+  end
+end
+
+describe 'DebugTask' do
+  it 'raises an error with debugging statements' do
+    allow(STDIN).to receive(:read).and_return('{"name": "Tom"}')
+    regex = /\[\"debugging statement\",\"another debugging statement\"\]/
+
+    # This needs to be done before the process that exits is run
+    expect(STDOUT).to receive(:print).with(regex)
+
+    begin
+      DebugTask.run
+    rescue SystemExit => e
+      expect(e.status).to eq(1)
+    else
+      raise 'The DebugTask test did not exit 1 as expected'
     end
   end
 end


### PR DESCRIPTION
This adds two helper methods to the task helper.

### `debug`

This method logs arbitrary values as debugging statements that are added
under the `details` field when a `TaskError` is raised.

### `debug_statements`

This method returns the current list of debugging statements.

Part of puppetlabs/bolt#1647