### PR TITLE
(CISC-1018) Update metadata support for Puppet 7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3 
+  TargetRubyVersion: 2.5
   Exclude:
     - 'Rakefile'
     - 'Gemfile'

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.7.0",


### PR DESCRIPTION
While the module installs and run fine as a dependency or explicitly via code manager, anything that checks the metadata complains that this will not work with 2019.x which runs Puppet 6. 

Bumped further for the incoming Puppet 7 2020.x release. 

Manually tested with Comply, the gem happy runs our tasks.