### PR TITLE
(maint) Auto-enable new cops, fix Rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.3 
+  TargetRubyVersion: 2.5
+  NewCops: enable
   Exclude:
     - 'Rakefile'
     - 'Gemfile'

--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -33,12 +33,13 @@ class TaskHelper
   # Accepts a Data object and returns a copy with all hash keys
   # symbolized.
   def self.walk_keys(data)
-    if data.is_a? Hash
+    case data
+    when Hash
       data.each_with_object({}) do |(k, v), acc|
         v = walk_keys(v)
         acc[k.to_sym] = v
       end
-    elsif data.is_a? Array
+    when Array
       data.map { |v| walk_keys(v) }
     else
       data
@@ -46,7 +47,7 @@ class TaskHelper
   end
 
   def self.run
-    input = STDIN.read
+    input = $stdin.read
     params = walk_keys(JSON.parse(input))
 
     # This method accepts a hash of parameters to run the task, then executes
@@ -56,13 +57,13 @@ class TaskHelper
     task   = new
     result = task.task(params)
 
-    if result.class == Hash
-      STDOUT.print JSON.generate(result)
+    if result.instance_of?(Hash)
+      $stdout.print JSON.generate(result)
     else
-      STDOUT.print result.to_s
+      $stdout.print result.to_s
     end
   rescue TaskHelper::Error => e
-    STDOUT.print({ _error: e.to_h }.to_json)
+    $stdout.print({ _error: e.to_h }.to_json)
     exit 1
   rescue StandardError => e
     details = {
@@ -71,7 +72,7 @@ class TaskHelper
     }.compact
 
     error = TaskHelper::Error.new(e.message, e.class.to_s, details)
-    STDOUT.print({ _error: error.to_h }.to_json)
+    $stdout.print({ _error: error.to_h }.to_json)
     exit 1
   end
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../files/task_helper.rb'
+require_relative '../files/task_helper'
 require 'json'
 
 class EmptyTask < TaskHelper; end
@@ -41,14 +41,14 @@ end
 
 describe 'EmptyTask' do
   it 'returns no method when task() is not provided' do
-    allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
+    allow($stdin).to receive(:read).and_return('{"name": "Lucy"}')
     msg = 'The task author must implement the `task` method in the task'
     result = { _error:
                { kind: 'tasklib/not-implemented',
                  msg: msg,
                  details: {} } }
     # This needs to be done before the process that exits is run
-    expect(STDOUT).to receive(:print).with(result.to_json)
+    expect($stdout).to receive(:print).with(result.to_json)
 
     begin
       EmptyTask.run
@@ -62,12 +62,12 @@ end
 
 describe 'ErrorTask' do
   it 'raises an error' do
-    allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
+    allow($stdin).to receive(:read).and_return('{"name": "Lucy"}')
     result = { _error: { kind: 'task/error-kind',
                          msg: 'task error message',
                          details: 'Additional details' } }
     # This needs to be done before the process that exits is run
-    expect(STDOUT).to receive(:print).with(result.to_json)
+    expect($stdout).to receive(:print).with(result.to_json)
 
     begin
       ErrorTask.run
@@ -81,11 +81,11 @@ end
 
 describe 'DebugTask' do
   it 'raises an error with debugging statements' do
-    allow(STDIN).to receive(:read).and_return('{"name": "Tom"}')
-    regex = /\[\"debugging statement\",\"another debugging statement\"\]/
+    allow($stdin).to receive(:read).and_return('{"name": "Tom"}')
+    regex = /\["debugging statement","another debugging statement"\]/
 
     # This needs to be done before the process that exits is run
-    expect(STDOUT).to receive(:print).with(regex)
+    expect($stdout).to receive(:print).with(regex)
 
     begin
       DebugTask.run
@@ -99,9 +99,9 @@ end
 
 describe 'EchoTask' do
   it 'runs an echo task' do
-    allow(STDIN).to receive(:read).and_return('{"name": "Lucy"}')
+    allow($stdin).to receive(:read).and_return('{"name": "Lucy"}')
     out = JSON.dump('result' => 'Hi, my name is Lucy')
-    expect(STDOUT).to receive(:print).with(out)
+    expect($stdout).to receive(:print).with(out)
     EchoTask.run
   end
 end
@@ -115,13 +115,13 @@ describe 'SymbolizeTask' do
     # The task will only return these values if the keys
     # are properly symbolized.
     symbols = { nested_hash: 'foo', array_hash: 'bar' }
-    allow(STDIN).to receive(:read).and_return(JSON.dump(params))
+    allow($stdin).to receive(:read).and_return(JSON.dump(params))
     # In order to verify that symbolizing keys has not corrupted
     # the structure of the parameters the task returns the params
     # hash it received. This is merged with the result of looking
     # up the symbolized keys.
     out = JSON.dump('result' => JSON.dump(params.merge(symbols)))
-    expect(STDOUT).to receive(:print).with(out)
+    expect($stdout).to receive(:print).with(out)
     SymbolizeTask.run
   end
 end


### PR DESCRIPTION
This configures rubocop to auto-enable new cops in order to avoid having
to update the rubocop configuration with every new release. This also
fixes rubocop errors that were causing CI to fail.