### PR TITLE
(maint) Bump maximum Puppet version, prep for 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.6.0
+
+### New features
+
+* Increase maximum Puppet version to Puppet 8, making the module usable with Puppet 7.
+
 ## Release 0.5.1
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library handles parsing JSON input, serializing the result as JSON output, 
 
 ## Requirements
 
-This library works with Ruby 2.3 and later.
+This library works with Ruby 2.3 and later, though is tested using Ruby 2.4 and 2.5.
 
 ## Setup
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ruby_task_helper",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "author": "Puppet, Inc.",
   "summary": "A helper for writing tasks in ruby",
   "license": "Apache-2.0",
@@ -57,7 +57,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.7.0",


### PR DESCRIPTION
This bumps the maximum Puppet version to 7.x, and preps the module for
release so that the update can be consumed.