### PR TITLE
Also serialize Arrays to JSON

### DIFF
--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -57,7 +57,7 @@ class TaskHelper
     task   = new
     result = task.task(params)
 
-    if result.instance_of?(Hash)
+    if result.instance_of?(Hash) || result.instance_of?(Array)
       $stdout.print JSON.generate(result)
     else
       $stdout.print result.to_s

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -25,6 +25,14 @@ class EchoTask < TaskHelper
   end
 end
 
+class ArrayTask < TaskHelper
+  def task(name: nil)
+    [
+      { package: 'puppet-bolt', version: '3.20.0' }
+    ]
+  end
+end
+
 class SymbolizeTask < TaskHelper
   def task(params)
     # Test that the keys have been symbolized.
@@ -103,6 +111,15 @@ describe 'EchoTask' do
     out = JSON.dump('result' => 'Hi, my name is Lucy')
     expect($stdout).to receive(:print).with(out)
     EchoTask.run
+  end
+end
+
+describe 'ArrayTask' do
+  it 'returns valid JSON' do
+    allow($stdin).to receive(:read).and_return('{"name": "Lucy"}')
+    out = '[{"package":"puppet-bolt","version":"3.20.0"}]'
+    expect($stdout).to receive(:print).with(out)
+    ArrayTask.run
   end
 end
 


### PR DESCRIPTION
The code currently serialize Hash to JSON, but does not do so for
Array, resulting in a serialization using #to_s to be done.  While an
Array of scalars is serialized by #to_s in a String which is a valid
JSON document, Hash are serialized with a Ruby specific-notation, i.e.
`{:foo=>"bar"}` instead of `{"foo": "bar"}`.  As a result, a task which
returns an array of structured results does not emit a processable
output.

Ensure a returned Array is serialized to JSON by the helper so that any
content can be processed as valid JSON data.
