### PR TITLE
(BOLT-1585) Support for ruby 3

### DIFF
--- a/files/task_helper.rb
+++ b/files/task_helper.rb
@@ -55,7 +55,7 @@ class TaskHelper
     # @param [Hash] params A hash of params for the task
     # @return [Hash] The result of the task
     task   = new
-    result = task.task(params)
+    result = task.task(**params)
 
     if result.instance_of?(Hash)
       $stdout.print JSON.generate(result)


### PR DESCRIPTION
Changes to the way keyworkd and positional arguments are handled in ruby 3 https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/ some of the tasks shipped with bolt that use the ruby task helper no longer work with both ruby 2 and 3. When task arguments are supplied to the task method (which is implemented by the consumer of the task helper) we want to support both keyword arguments AND a positional hash parameter. The way to accomplish this that works for both ruby 2 and 3 is to destructure the hash of params when invoking the `task` method. This will accomidate task authors who use a positional argument and those that use keyword arguments for both ruby 2 and 3