### PR TITLE
Release prep v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.0
+
+### Major changes
+
+* Module upgraded to be Puppet 8 compatible
+
 ## Release 0.6.1
 
 ### Bug fixes

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ruby_task_helper",
-  "version": "0.6.1",
+  "version": "1.0.0",
   "author": "Puppet, Inc.",
   "summary": "A helper for writing tasks in ruby",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release prep for the ruby_task_helper module

Please verify before merging:
- [x] last CI run is green
- [x] [Changelog](https://github.com/puppetlabs/puppetlabs-ruby_task_helper/blob/release-prep/CHANGELOG.md) is readable
- [x] Ensure the [changelog](https://github.com/puppetlabs/puppetlabs-ruby_task_helper/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/puppetlabs/puppetlabs-ruby_task_helper/blob/release-prep/metadata.json) version match